### PR TITLE
Adds an option to change language only when the Fn is released

### DIFF
--- a/Sources/FnLangSwitch/AppDelegate.swift
+++ b/Sources/FnLangSwitch/AppDelegate.swift
@@ -57,7 +57,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func openSettings() {
         if settingsWindow == nil {
             let w = NSWindow(
-                contentRect: NSRect(x: 0, y: 0, width: 400, height: 160),
+                contentRect: NSRect(x: 0, y: 0, width: 400, height: 200),
                 styleMask: [.titled, .closable],
                 backing: .buffered,
                 defer: false

--- a/Sources/FnLangSwitch/KeyMonitor.swift
+++ b/Sources/FnLangSwitch/KeyMonitor.swift
@@ -4,14 +4,25 @@ final class KeyMonitor {
     private let inputSourceManager: InputSourceManager
     private var monitor: Any?
     private var fnWasDown = false
+    private var otherKeyPressed = false
+    private var fnPressTime: UInt64 = 0
+
+    /// Maximum interval (ns) for a plain Fn tap — a quick tap switches, a held Fn does not.
+    private static let tapThresholdNs: UInt64 = 400_000_000 // 400 ms
+
+    private var switchOnRelease: Bool {
+        UserDefaults.standard.bool(forKey: "switchOnRelease")
+    }
 
     init(inputSourceManager: InputSourceManager) {
         self.inputSourceManager = inputSourceManager
     }
 
     func start() {
-        monitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
-            self?.handleFlags(event)
+        monitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.flagsChanged, .keyDown, .keyUp, .systemDefined]
+        ) { [weak self] event in
+            self?.handleEvent(event)
         }
     }
 
@@ -20,11 +31,41 @@ final class KeyMonitor {
         monitor = nil
     }
 
+    private func handleEvent(_ event: NSEvent) {
+        if event.type == .flagsChanged {
+            handleFlags(event)
+        } else if fnWasDown && switchOnRelease {
+            otherKeyPressed = true
+        }
+    }
+
     private func handleFlags(_ event: NSEvent) {
         let fnDown = event.modifierFlags.contains(.function)
+
         if fnDown && !fnWasDown {
-            inputSourceManager.toggleInputSource()
+            // Fn just pressed
+            if switchOnRelease {
+                otherKeyPressed = false
+                fnPressTime = mach_absolute_time()
+            } else {
+                inputSourceManager.toggleInputSource()
+            }
+        } else if !fnDown && fnWasDown {
+            // Fn just released
+            if switchOnRelease {
+                let elapsed = mach_absolute_time() - fnPressTime
+                var info = mach_timebase_info_data_t()
+                mach_timebase_info(&info)
+                let elapsedNs = elapsed * UInt64(info.numer) / UInt64(info.denom)
+                if !otherKeyPressed && elapsedNs < Self.tapThresholdNs {
+                    inputSourceManager.toggleInputSource()
+                }
+            }
+        } else if fnDown && fnWasDown && switchOnRelease {
+            // Other modifier changed while Fn is held (e.g. Fn+Shift)
+            otherKeyPressed = true
         }
+
         fnWasDown = fnDown
     }
 

--- a/Sources/FnLangSwitch/SettingsWindow.swift
+++ b/Sources/FnLangSwitch/SettingsWindow.swift
@@ -6,6 +6,8 @@ struct SettingsView: View {
         SMAppService.mainApp.status == .enabled
     }()
 
+    @AppStorage("switchOnRelease") private var switchOnRelease = false
+
     var body: some View {
         VStack(spacing: 16) {
             Text("Press the FN key to switch keyboard input source.")
@@ -18,6 +20,7 @@ struct SettingsView: View {
                         setLaunchAtLogin(newValue)
                     }
 
+                Toggle("Switch on Fn release (ignores Fn+key combos)", isOn: $switchOnRelease)
             }
 
             Spacer()
@@ -27,7 +30,7 @@ struct SettingsView: View {
             }
         }
         .padding(24)
-        .frame(width: 400, height: 160)
+        .frame(width: 400, height: 200)
     }
 
     private func setLaunchAtLogin(_ enabled: Bool) {


### PR DESCRIPTION
Adds an option to change language only when the Fn is released to allow using the Fn key for it's "normal" use.
The "on release" mode works on a timing basis so is not perfect, but it's a pretty good compromise.

Resolves #12 